### PR TITLE
Work around failure-derive compilation error when installing this crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-ensure-prefix"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "cargo 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,6 +139,7 @@ name = "cargo-ensure-prefix"
 version = "0.1.4"
 dependencies = [
  "cargo 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-ensure-prefix"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Daniel Wagner-Hall <dawagner@gmail.com>"]
 edition = "2018"
 description = "Cargo subcommand to check that all target files have a fixed prefix."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ license = "BSD-3-Clause"
 [dependencies]
 cargo = "0.32"
 structopt = "0.3"
+# Workaround incompatibility between failure_derive and quote 1.0.3.
+# See https://users.rust-lang.org/t/failure-derive-compilation-error/39062
+quote = "=1.0.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,7 +107,7 @@ fn parse(opt: Opt) -> Result<Params, String> {
     let packages = Packages::from_flags(all, exclude, package)
         .map_err(|err| format!("Error parsing package spec: {}", err))?;
 
-    let paths_to_check = list_paths(manifest_path.clone(), &packages)?;
+    let paths_to_check = list_paths(manifest_path, &packages)?;
 
     Ok(Params {
         paths_to_check,


### PR DESCRIPTION
At the moment there's about 800 crates affected by this error:

error[E0433]: failed to resolve: could not find `__rt` in `quote`
   --> ~/.cargo/registry/src/github.com-1ecc6299db9ec823/failure_derive-0.1.6/src/lib.rs:107:70
    |
107 | fn display_body(s: &synstructure::Structure) -> Result<Option<quote::__rt::TokenStream>, Error> {
    |                                                                      ^^^^ could not find `__rt` in `quote`
The quick workaround is to add:

quote = "=1.0.2"
to Cargo.toml dependencies (anywhere in the project, Cargo will figure it out).

The problem is caused by an incompatibility between failure_derive (which used a private-ish name) and quote 1.0.3 (which renamed it).

See this thread for context: https://users.rust-lang.org/t/failure-derive-compilation-error/39062